### PR TITLE
Fix NullReferenceException when ItemSource contains 'null'  values

### DIFF
--- a/WPFTextBoxAutoComplete/AutoCompleteBehavior.cs
+++ b/WPFTextBoxAutoComplete/AutoCompleteBehavior.cs
@@ -150,7 +150,7 @@ namespace WPFTextBoxAutoComplete
 				(
 					from subvalue
 					in values
-					where subvalue.Length >= textLength
+					where subvalue != null && subvalue.Length >= textLength
 					select subvalue
 				)
 				where value.Substring(0, textLength).Equals(tb.Text, comparer)


### PR DESCRIPTION
If the AutoCompletionItemSource contains one or more elements with a value of 'null' it caused a NullReferenceException. Adding an additional null check prevents this.

